### PR TITLE
altering default setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+DJ_HOST=database
+DJ_USER=root
+DJ_PASS=microns123
+EXTERNAL_NOTEBOOKS=./notebooks

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-# dotenv file
-.env
+notebooks/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ COPY README.md /microns-nda-access/.
 COPY Dockerfile /microns-nda-access/.
 COPY docker-compose.yml /microns-nda-access/.
 RUN git clone https://github.com/cajal/microns_phase3_nda
+RUN pip3 install torch==1.9.0+cpu torchvision==0.10.0+cpu torchaudio==0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
+#RUN pip3 install torch==1.8.1
 RUN pip3 install -e microns_phase3_nda/ --use-feature=in-tree-build
 RUN pip3 install git+https://github.com/AllenInstitute/em_coregistration.git@phase3
 

--- a/README.md
+++ b/README.md
@@ -116,16 +116,11 @@ The external hostname of the machine can be used in place of `127.0.1.1`.
 
 ## .env file
 
-It can be useful to place the environment variables already noted above into a `.env` (dotenv) file in the same folder as the docker-compose.yml file which will automatically read in the use the key=value pairs as environment variables.
+This docker-compose file is optimized to get a single machine up and running quickly with the database and notebook server.
+However, you  might want to run a server and let many other clients connect to it, rather than having all the clients run their own database.
 
-An helpful example for this situation is as follows:
-```env
-DJ_HOST=<hostname>
-DJ_USER=root
-DJ_PASS=microns123
-EXTERNAL_NOTEBOOKS=/path/to/external_folder
-```
+If so, you only need to run the notebook portion of the docker-compose file, but then you must modify the existing .env file to point to the host of an working database.  To do so you need to modify the DJ_HOST variable of the .env file provided.
 
 replacing the "\<hostname>" with the hostname of the machine hosting the database (can use `127.0.1.1` if the notebook service has `network_mode: 'host'` enabled, but otherwise must use the network ip of the computer hosting the database container).
 
-Also replacing the "/path/to/external_folder" to a real folder location.
+You can also replace the ./notebooks reference to a folder to a folder the of your choice.

--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ If so, you only need to run the notebook portion of the docker-compose file, but
 
 replacing the "\<hostname>" with the hostname of the machine hosting the database (can use `127.0.1.1` if the notebook service has `network_mode: 'host'` enabled, but otherwise must use the network ip of the computer hosting the database container).
 
-You can also replace the ./notebooks reference to a folder to a folder the of your choice.
+You can also replace the ./notebooks reference to a folder of your choice.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,16 @@ services:
     # #       would need to use the network ip of the database hosting computer.
     # ports:
     #   - "${NOTEBOOK_PORT:-8888}:8888" # Jupyter notebook, defaults to port 8888 unless overridden by the NOTEBOOK_PORT env variable
-    network_mode: 'host'
+    # network_mode: 'host'
+    links:
+      - database
+    ports: 
+      - 8888:8888
     
   database:
     image: microns-phase3-nda-db-v3:latest # This image should be first loaded from the downloaded tar file, reference SETUP.md for more information.
     command: --default-authentication-plugin=mysql_native_password --max-allowed-packet=2147483648
     restart: always
-    network_mode: 'host'
+    ports:
+      - 3306:3306
+#    network_mode: 'host'


### PR DESCRIPTION
I made some suggested changes that helped me get this started more easily on a mac with the latest version of docker installed.  I don't know why pytorch wasn't building, but i suspect the cpu installation will be more universal than a gpu enabled one anyway.

second, I think its best practice to avoid host networking.  It's only necessary to have dns work properly.   Connecting to notebooks from within docker is possible by using the docker dns and links as i've done here.

I've added a .env file because it wasn't running without an EXTERNAL_NOTEBOOKS defined, and by starting with some default will let users get started with less thinking rather than adding more mandatory steps.   You can describe adjustments/modifications that might be more efficent/desirable in some situation, but I feel like the MVP should work right out of the box. 