### PR TITLE
v8 updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,16 +21,15 @@ WORKDIR /src
 COPY README.md /microns-nda-access/.
 COPY Dockerfile /microns-nda-access/.
 COPY docker-compose.yml /microns-nda-access/.
-RUN git clone https://github.com/cajal/microns_phase3_nda
+RUN git clone --depth 1 --branch v8 https://github.com/cajal/microns_phase3_nda
 RUN pip3 install torch==1.9.0+cpu torchvision==0.10.0+cpu torchaudio==0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
-#RUN pip3 install torch==1.8.1
 RUN pip3 install -e microns_phase3_nda/
 RUN pip3 install git+https://github.com/AllenInstitute/em_coregistration.git@phase3
 
 # Set up work environment
 WORKDIR /notebooks
 COPY README.md .
-RUN mkdir tutorials/ && cp -r /src/microns_phase3_nda/notebooks/. tutorials/.
+RUN mkdir tutorial_notebooks/ && cp -r /src/microns_phase3_nda/tutorial_notebooks/. tutorial_notebooks/.
 RUN mkdir workspace/
 
 # Start jupyter notebook

--- a/README.md
+++ b/README.md
@@ -1,159 +1,166 @@
 # microns-nda-access
 
-This guide will walk you through setting up the database container and the access methods for the [microns_phase3_nda](https://github.com/cajal/microns_phase3_nda) data.
+This guide will walk you through setting up the `nda` database locally. The `nda` database contains the functional data for the MICrONS project.
 
-The data and files for these can be found in the microns-explorer [here](https://www.microns-explorer.org/cortical-mm3#f-data).
+An overview of the functional data and other access options can be found in [MICrONS Explorer](https://www.microns-explorer.org/cortical-mm3#f-data).
 
-or
+The current version of this repository and the database is v8.
 
-you can download the container image tar file using the [aws cli tool](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+This repo is synchronized with the [`microns_phase3_nda`](https://github.com/cajal/microns_phase3_nda) repo, which contains the Jupyter notebooks and utilities to interact with the functional data. The Jupyter Docker environment launched by following this tutorial will install `microns_phase3_nda` and make the tutorials easily accessible.
 
-```bash
-aws s3 cp s3://bossdb-open-data/iarpa_microns/minnie/functional_data/two_photon_processed_data_and_metadata/database_v7/functional_data_database_container_image_v7.tar . --no-sign-request
-```
+# Database Setup
 
-# Prerequisites
+There are two main MySQL database setup options covered here.
 
-- More than 120 GB of free disk space (around double that, ~222 GB, to load the image from the tar archive the first time, and potentially up to that amount to query from the database)
+1. Set up a Docker container environment with the database and all data pre-ingested. [Skip to section](#database-container)
+
+2. Download a data dump for manual ingestion into an existing MySQL database. [Skip to section](#manual-sql-ingesting)
+
+After the database is set up, continue on to the [Access](#access) section to begin working with the data.
+
+## Database container
+
+### Requirements
+
+- More than 120 GB of free disk space (around double that, ~222 GB, to load the image from the tar archive for the first time, and potentially up to that amount to query from the database)
 - [Docker](https://docs.docker.com/desktop/)
 - [docker-compose](https://docs.docker.com/compose/)
 
-# Setup
+### Step 1: Download the container image tar file to an accessible location. There are two methods:
 
-This section comes in two parts, the first is the database containing the `microns-phase3-nda` schema and the second is for the container to access that data with DataJoint in a Jupyter notebook server that will come with tutorials or with the mysql-client.
+1. Use the [aws command line tool](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+    ```bash
+    aws s3 cp s3://bossdb-open-data/iarpa_microns/minnie/functional_data/two_photon_processed_data_and_metadata/database_v8/functional_data_database_container_image_v8.tar . --no-sign-request
+    ```
+2. Download the file directly by clicking [here](https://bossdb-open-data.s3.amazonaws.com/iarpa_microns/minnie/functional_data/two_photon_processed_data_and_metadata/database_v8/functional_data_database_container_image_v8.tar). (Warning: download will start automatically.)
 
-If you wish to handle importing the SQL file into an existing database yourself you can skip this next `Database` section, and view the basic instructions for ingesting the database into an existing MySQL instance in the `Manual SQL Ingesting` section below. Then go back to the `Access` section.
 
-# Database
-
-The docker image must first be downloaded from the microns-explorer (in a tar archive format, link is at the top).
-Save this to an accessible location.
-
-In the location where you've stored the downloaded image archive you then will load the image to your local filesystem:
+### Step 2: In the directory where you've stored the downloaded image archive you then will load the image to your local filesystem:
 
 ```bash
-docker load < functional_data_database_container_image_v7.tar
+docker load --input functional_data_database_container_image_v8.tar
 ```
 
-OR
+To start the database run:
 
-```bash
-docker load --input functional_data_database_container_image_v7.tar
-```
-
-To start the database you can either `Docker` or `docker-compose`:
-
-The data is this database, started with both Docker or docker-compose, is not persistent and changes will be lost when exiting the container.
-
-## docker-compose
-
-This would be the preferred method for starting the service as it is more fully configured.
 ```bash
 docker-compose up -d database
 ```
+`WARNING`: Any changes made to the database are not persistent and changes will be lost when exiting the container.
 
-## Docker
-
-Running the container without docker-compose is also an option.
-
-```bash
-docker run --network="host" --detach microns-phase3-nda-database:latest
-```
-
-# Access
-
-The data can be accessed in two ways, either with the mysql-client or through DataJoint in a Jupyter notebook service.
-
-The default user and password for the database are:
+The default username and password for the database are:
 
 `username:` root  
 `password:` microns123
 
-The first accesses of the data may take awhile, but should be fast after that.
+To access the database, continue on to the [Access](#access) section.
 
-## Jupyter Notebook (DataJoint)
+NOTE: The first accesses of the data may take awhile, but should be fast after that.
 
-You can use this access repository and build the notebook image yourself with `Docker` and `docker-compose`.
+## Manual SQL Ingesting
 
-Using the docker-compose you can start the container with:
+### Requirements
+
+- 115GB of free disk space (around double that ~230 GB during ingest if the database is on the same disk. The SQL dump file can be deleted after ingest to recover space.)
+
+To download the SQL dump file with the [aws command line tool](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) run:
+
+```bash
+aws s3 cp s3://bossdb-open-data/iarpa_microns/minnie/functional_data/two_photon_processed_data_and_metadata/database_v8/functional_data_database_sql_dump_v8.sql . --no-sign-request
+```
+
+Then to ingest it into your existing database, you first must create an empty schema by the name of `microns_phase3_nda`, then run this command (the `--compress` flag is optional) after replacing `[your-custom-databse-ip]` and `[your-username]` with your own info:
+
+```bash
+mysql --compress --max_allowed_packet=2147483648 -h[your-custom-database-ip] -u[your-username] -p microns_phase3_nda < functional_data_database_sql_dump_v8.sql
+```
+
+This should take several hours.
+
+# Access
+This section describes how to launch a a Jupyter Docker container that contains tutorials on how to use [DataJoint](https://datajoint.com/) to access the database. 
+
+If you performed a manual SQL ingest described above continue on [here](#run-the-jupyter-notebook-environment-with-your-own-database).
+
+## Run the Jupyter Notebook (DataJoint) with the database container
+
+To start the container run:
 
 ```bash
 docker-compose up -d notebook
 ```
 
-which can then be accessed at http://localhost:8888/tree (this uses the default port of 8888).
+NOTE: it will take several minutes to build on the first run
+
+Continue on [here](#launch-the-jupyter-environment) to launch the jupyter environment.
+
+## Run the Jupyter Notebook environment with your own database
+
+By **default**  the notebooks will connect with the database using the environment variable defaults set in `.env`.
+
+To input the credentials to your own database, either:
+
+1. modify the `.env` file in this directory by pointing `DJ_HOST` the IP address of your database, and `DJ_USER` and `DJ_PASS` to your database username and password.
+
+OR 
+
+2. Continue on and adjust these later using DataJoint
+
+In this repository directory run:
+
+```bash
+docker-compose up -d notebook-only
+```
+
+To launch the Jupyter environment continue [here](#launch-the-jupyter-environment).
+
+To adjust credentials using DataJoint, in a notebook run the following after replacing the angle bracket placeholders with your information as a `str`:
+
+```python
+import datajoint as dj
+
+dj.config['database.host'] = <YOUR DATABASE IP ADDRESS>
+dj.config['database.user'] = <YOUR USERNAME>
+dj.config['database.password'] = <YOUR PASSWORD>
+```
+
+## Launch the Jupyter environment
+
+The Jupyter environment can then be accessed at http://localhost:8888/tree (this uses the default port of 8888).
 
 http://localhost:8888 will send to Jupyter Lab, but the plots/graphics might not all work out-of-the-box without enabling jupyter lab extensions.
 
-The database host will default to http://localhost:3306, or from the notebook container it can be accessed via the `database` link.
+Once inside the Jupyter environment, navigate to the `tutorial_notebooks` folder and run through the tutorials to ensure everything is configured properly.
 
-An external, persistent workspace can be mounted to the internal `workspace` folder by settings the `EXTERNAL_NOTEBOOKS` env variable to a folder of choice.
+NOTE: The `notebook` folder in this repo is mounted by default to a folder called `workspace` in the container. To modify which folder is mapped to `notebook` see [here](#modify-external_notebooks-in-env)
 
-By **default**  the notebooks will connect with the database using the environment variable defaults set in `.env`, so you should be able to access the data and python modules like below with the basic setup in these instructions:
+# Additional Notes
 
-```python
-import datajoint as dj
+## Modify EXTERNAL_NOTEBOOKS in .env
+To change which directory is mapped to the `notebooks` folder in the container, point the`EXTERNAL_NOTEBOOKS` variable in the `.env` file of this repo to a different directory of choice. To apply the changes in the `.env` file if the container is already up, then the `docker-compose up -d notebook` or `docker-compose up -d notebook-only` command would need to be rerun. 
 
-from phase3 import nda, func, utils
-```
+## Default database host for the `notebook` docker-compose service
 
-However, if it's wanted to manually set the connection credentials and/or host in a notebook, below is an example of that:
-
-```python
-import datajoint as dj
-
-dj.config['database.host'] = 'database'
-dj.config['database.user'] = 'root'
-dj.config['database.password'] = 'microns123'
-
-from phase3 import nda, func, utils
-```
-
-The pre-built image of the access container, microns-phase3-nda-notebook, can be downloaded from the microns-explorer linked above and loaded as a docker image the same way as the database archive above instead of building it yourself.
-
-```bash
-docker load --input functional_data_notebook_container_image_v7.tar
-```
-
-## mysql-client
-
-From the local machine you can access it this way
-
-```bash
-mysql -h 127.0.0.1 -u root -p
-```
-
-which will then prompt for the password (the default from above is `microns123`) and will open an interactive mysql terminal.
+The database host will default to http://localhost:3306, or from the notebook container it can be accessed via the `database` link as `DJ_HOST` value.
 
 ## .env file
 
 This docker-compose file is optimized to get a single machine up and running quickly with the database and notebook server.
 However, you  might want to run a server and let many other clients connect to it, rather than having all the clients run their own database.
 
-If so, you only need to run the notebook portion of the docker-compose file, but then you must modify the existing .env file to point to the host of an working database.  To do so you need to modify the DJ_HOST variable of the .env file provided.
+If so, you only need to run the notebook portion of the docker-compose file, but then you must modify the existing .env file to point to the host of a working database.  To do so you need to modify the DJ_HOST variable of the .env file provided.
 
 replacing the "\<hostname>" with the hostname of the machine hosting the database (can use `127.0.1.1` if the notebook service has `network_mode: 'host'` enabled, but otherwise must use the network ip of the computer hosting the database container).
 
-You can also replace the ./notebooks reference to a folder of your choice.
+## Access database with mysql-client
 
-The links section of the notebook service in docker-compose.yml will also need to be commented out or it'll expect the database container image to be present.
+See detailed instructions on the [mysql website](https://dev.mysql.com/doc/mysql-getting-started/en/)
 
-## Manual SQL Ingesting
+The default user and password for the database in the container are:
 
-If you want to ingest/import the SQL file into an existing MySQL instance you must first directly download the SQL dump file, this can be done with:
+`username:` root  
+`password:` microns123
 
-```bash
-aws s3 cp s3://bossdb-open-data/iarpa_microns/minnie/functional_data/two_photon_processed_data_and_metadata/database_v7/functional_data_database_sql_dump_v7.sql . --no-sign-request
-```
+# Known Issues
 
-Then to ingest it into your existing database, you first must create an empty schema by the name of `microns_phase3_nda`, then run this command (the `--compress` flag is optional) after replacing `[your-custom-databse-ip]` and `[your-username]` with your own info:
-
-```bash
-mysql --compress --max_allowed_packet=2147483648 -h[your-custom-database-ip] -u[your-username] -p microns_phase3_nda < functional_data_database_sql_dump_v7.sql
-```
-
-This should take several hours.
-
-## Known Issues
-
-- For Windows and Mac (where you have to allocate memory ahead of time for Docker) you might need to allocate 8-12 GB to Docker to ensure you aren't running into the upper limits of the default allocated memory limits. Otherwise you might run into a "Lost Connection to MYSQL database" exception, which can be temporarily fixed by restarting the notebook kernel.
+- For Mac (where you have to allocate memory ahead of time for Docker) you might need to allocate 8-12 GB to Docker to ensure you aren't running into the upper limits of the default allocated memory limits. Otherwise you might run into a "Lost Connection to MYSQL database" exception, which can be temporarily fixed by restarting the notebook kernel.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,13 @@ services:
     ports:
       - 3306:3306
 #    network_mode: 'host'
+
+  notebook-only:
+    image: microns-phase3-nda-notebook:latest
+    build:
+      context: .
+    env_file: .env
+    volumes:
+      - ${EXTERNAL_NOTEBOOKS}:/notebooks/workspace
+    ports: 
+      - 8888:8888


### PR DESCRIPTION
Major changes - 
* Add a `notebook-only` docker-compose service for users who manually ingest the SQL data but still want to run the Jupyter Docker container
* Restructure README and update links to v8
* Edit Dockerfile to point to the v8 tag of [`microns_phase3_nda`](https://github.com/cajal/microns_phase3_nda/tree/v8) repo